### PR TITLE
gtk-range: fix regression from previous patch

### DIFF
--- a/gtk/gtkrange.h
+++ b/gtk/gtkrange.h
@@ -62,8 +62,6 @@ struct _GtkRangeClass
   gchar *slider_detail;
   gchar *stepper_detail;
 
-  gboolean no_warp;
-
   void (* value_changed)    (GtkRange     *range);
   void (* adjust_bounds)    (GtkRange     *range,
                              gdouble	   new_value);
@@ -79,6 +77,8 @@ struct _GtkRangeClass
   gboolean (* change_value) (GtkRange     *range,
                              GtkScrollType scroll,
                              gdouble       new_value);
+
+  gboolean no_warp;
 
   /* Padding for future expansion */
   void (*_gtk_reserved1) (void);


### PR DESCRIPTION
Causes: https://bugs.launchpad.net/linuxmint/+bug/1385681

(new class property should have been appended rather than inserted
into the existing properties.)
