### PR TITLE
gtktreeview: Fix cancel of column re-ordering via the Escape key.

### DIFF
--- a/gtk/gtktreeview.c
+++ b/gtk/gtktreeview.c
@@ -5782,7 +5782,7 @@ gtk_tree_view_key_press (GtkWidget   *widget,
       if (event->keyval == GDK_KEY_Escape)
 	{
 	  tree_view->priv->cur_reorder = NULL;
-	  gtk_tree_view_button_release_drag_column (widget, NULL);
+	  gtk_tree_view_button_release_drag_column (widget, (GdkEventButton *) event);
 	}
       return TRUE;
     }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1162288